### PR TITLE
added interval instead of timeout to tool loading code

### DIFF
--- a/src/pages/PdfViewerPage/PdfViewerPage.tsx
+++ b/src/pages/PdfViewerPage/PdfViewerPage.tsx
@@ -90,20 +90,56 @@ const PdfViewerPage: FC<PdfViewerPageProps> = ({
     HTMLElement | null | undefined
   >(null);
 
+  const [viewerNode, setViewerNode] = React.useState<HTMLIFrameElement | null>(
+    null,
+  );
+  const [sidebarCheckTimer, setSidebarCheckTimer] = React.useState<number>(0);
+
+  // A react version of setInterval, once the viewerNode is loaded, we try to
+  // set the reference details, knowledge graph and summary node states
+  React.useEffect(() => {
+    if (!viewerNode) {
+      setTimeout(() => setSidebarCheckTimer((cur) => cur + 1), 100);
+    } else {
+      let needToUpdate = false;
+
+      if (!referenceDetailsMountNode) {
+        needToUpdate = true;
+        setReferenceDetailsMountNode(
+          viewerNode?.contentDocument?.getElementById("referenceDetailsView"),
+        );
+      }
+
+      if (!knowledgeGraphMountNode) {
+        needToUpdate = true;
+        setKnowledgeGraphMountNode(
+          viewerNode?.contentDocument?.getElementById("knowledgeGraphView"),
+        );
+      }
+
+      if (!summaryMountNode) {
+        needToUpdate = true;
+        setSummaryMountNode(
+          viewerNode?.contentDocument?.getElementById("summaryView"),
+        );
+      }
+
+      if (needToUpdate) {
+        setTimeout(() => setSidebarCheckTimer((cur) => cur + 1), 100);
+      }
+    }
+  }, [
+    viewerNode,
+    sidebarCheckTimer,
+    referenceDetailsMountNode,
+    knowledgeGraphMountNode,
+    summaryMountNode,
+  ]);
+
+  // Once the iframe loads, set it in a state
   const viewerRef = React.useCallback((node: HTMLIFrameElement) => {
     if (node !== null) {
-      // This is not a solution...
-      setTimeout(() => {
-        setReferenceDetailsMountNode(
-          node?.contentDocument?.getElementById("referenceDetailsView"),
-        );
-        setKnowledgeGraphMountNode(
-          node?.contentDocument?.getElementById("knowledgeGraphView"),
-        );
-        setSummaryMountNode(
-          node?.contentDocument?.getElementById("summaryView"),
-        );
-      }, 5000);
+      setViewerNode(node);
     }
   }, []);
 

--- a/src/pages/PdfViewerPage/PdfViewerPage.tsx
+++ b/src/pages/PdfViewerPage/PdfViewerPage.tsx
@@ -97,9 +97,14 @@ const PdfViewerPage: FC<PdfViewerPageProps> = ({
 
   // A react version of setInterval, once the viewerNode is loaded, we try to
   // set the reference details, knowledge graph and summary node states
+  const TOOL_LOADING_INTERVAL = 100; // milliseconds
+
   React.useEffect(() => {
     if (!viewerNode) {
-      setTimeout(() => setSidebarCheckTimer((cur) => cur + 1), 100);
+      setTimeout(
+        () => setSidebarCheckTimer((cur) => cur + 1),
+        TOOL_LOADING_INTERVAL,
+      );
     } else {
       let needToUpdate = false;
 
@@ -125,7 +130,10 @@ const PdfViewerPage: FC<PdfViewerPageProps> = ({
       }
 
       if (needToUpdate) {
-        setTimeout(() => setSidebarCheckTimer((cur) => cur + 1), 100);
+        setTimeout(
+          () => setSidebarCheckTimer((cur) => cur + 1),
+          TOOL_LOADING_INTERVAL,
+        );
       }
     }
   }, [


### PR DESCRIPTION
Instead of having a 5 second timeout for loading the tools, the code now checks every 100ms if the iframe has loaded, and once it has loaded, it sets the state for each of the tools, allowing it to mount the tools to the sidebar through React portals.