### PR TITLE
Secondary open file removed

### DIFF
--- a/public/web/customToolbar.js
+++ b/public/web/customToolbar.js
@@ -24,6 +24,7 @@ function editToolBar() {
   /* Moving elements*/
   //addElemFromSecondaryToPrimary("previous","toolbarViewerMiddle")
   removeElement("openFile");
+  removeElement("secondaryOpenFile");
   registerCustomToolbarButtonHandlers();
 }
 


### PR DESCRIPTION
# Description
The option to upload a file would appear in the sidebar tools when the window is really small, or when the app is opened on mobile, so that tool is now also removed.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Screenshots
Before
![Sidebar](https://user-images.githubusercontent.com/87647515/208474303-ab517db6-dcb0-41aa-bed6-2c02fdffbe63.png)

After
![sidebar2](https://user-images.githubusercontent.com/87647515/208474319-c2db304d-69de-44b3-b65a-7d162315affd.png)

# Reference JIRA tickets : 

- SA-158

# Checklist:

Put an "x" in the brackets to check the checkbox.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in particularly hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding changes to JIRA tickets
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have merged develop into my branch and resolved possible conflicts
