### PR TITLE
[SA-173]/Knowledge Graph zoom fix, larger modal

### DIFF
--- a/src/components/KnowledgeGraphModal/KnowledgeGraphModal.scss
+++ b/src/components/KnowledgeGraphModal/KnowledgeGraphModal.scss
@@ -15,6 +15,7 @@
   .sa-knowledge-graph-modal-overlay {
     position: fixed;
     width: 100%;
+    height: 100%;
     background-color: rgba(159, 187, 170, 0.6);
     z-index: 1;
     top: 0px;
@@ -23,9 +24,10 @@
 
   .sa-knowledge-graph-modal-wrapper {
     background-color: var(--sa-neutral-color-2);
-    width: 1000px;
+    width: 80%;
+    height: 80%;
 
-    margin: 175px auto;
+    margin: 50px auto;
 
     border: 0px;
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);

--- a/src/components/KnowledgeGraphModal/KnowledgeGraphModal.scss
+++ b/src/components/KnowledgeGraphModal/KnowledgeGraphModal.scss
@@ -43,6 +43,7 @@
       gap: 20px;
     }
     .sa-knowledge-graph-modal-node-details {
+      width: 35%;
       .sa-knowledge-graph-modal-node-buttons {
         display: flex;
         justify-content: center;

--- a/src/components/KnowledgeGraphModal/KnowledgeGraphModal.tsx
+++ b/src/components/KnowledgeGraphModal/KnowledgeGraphModal.tsx
@@ -42,19 +42,25 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
   const [error, setError] = React.useState<boolean>(false);
   const [newElements, setNewElements] = React.useState<any>(elements);
 
-  // update the width  of the component when the component is mounted
+  // update the width and height of the component when the component is mounted
   React.useEffect(() => {
-    containerRef.current = document.getElementById(domIDs.root);
+    containerRef.current = document.getElementById("cytoscape-graph-container");
     if (containerRef.current) {
-      setStyle({ width: containerRef.current.offsetWidth, height: 450 });
+      setStyle({
+        width: 0.85 * containerRef.current.clientWidth,
+        height: 0.85 * containerRef.current.clientHeight,
+      });
     }
   }, [containerRef, domIDs.root]);
 
-  // update the width of the component whenever the parent container changes
+  // update the width and height of the component whenever the parent container changes
   React.useEffect(() => {
     function handleResize() {
       if (containerRef.current) {
-        setStyle({ width: containerRef.current.offsetWidth, height: 450 });
+        setStyle({
+          width: 0.85 * containerRef.current.clientWidth,
+          height: 0.85 * containerRef.current.clientHeight,
+        });
       }
     }
 
@@ -76,8 +82,9 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
     levelWidth: function (nodes: []) {
       return 2;
     },
-    fit: "true",
-    animate: "true",
+    fit: true,
+    pan: true,
+    animate: true,
   };
 
   graphStyle[1].style["background-color"] = (node: any) =>
@@ -153,6 +160,7 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
         >
           <div
             className={cs("sa-knowledge-graph-modal-wrapper", className)}
+            id="cytoscape-graph-container"
             onClick={(e) => e.stopPropagation()}
           >
             <TitleClose titleText="Knowledge Graph" handleClose={toggle} />
@@ -201,6 +209,19 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
                           duration: 1000,
                         }).play();
                       });
+                      cy.on("ready", function () {
+                        console.log("ready");
+                        setTimeout(() => {
+                          cy.animation({
+                            fit: {
+                              eles: newElements,
+                              padding: 10,
+                            },
+                            easing: "ease-in-out",
+                            duration: 1000,
+                          }).play();
+                        }, 500);
+                      });
                       myCy = cy;
                     }}
                     elements={newElements}
@@ -208,7 +229,6 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
                     stylesheet={graphStyle}
                     layout={layout}
                     wheelSensitivity={0.2}
-                    pan={{ x: 100, y: 200 }}
                     zoom={0.3}
                   />
                   {node ? (

--- a/src/components/KnowledgeGraphModal/KnowledgeGraphModal.tsx
+++ b/src/components/KnowledgeGraphModal/KnowledgeGraphModal.tsx
@@ -129,7 +129,6 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
         >
           <div
             className={cs("sa-knowledge-graph-modal-wrapper", className)}
-            id="cytoscape-graph-container"
             onClick={(e) => e.stopPropagation()}
           >
             <TitleClose titleText="Knowledge Graph" handleClose={toggle} />
@@ -172,7 +171,7 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
                         cy.animation({
                           fit: {
                             eles: node,
-                            padding: 50,
+                            padding: 150,
                           },
                           easing: "ease-in-out",
                           duration: 1000,
@@ -181,11 +180,6 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
 
                       // Get reference to the component
                       myCy = cy;
-
-                      // Make it so the graph is automatically fitted into container when it is resized
-                      cy.on("resize", () => {
-                        zoomOut();
-                      });
                     }}
                     elements={newElements}
                     style={{ width: "50vw", height: "70vh" }}

--- a/src/components/KnowledgeGraphModal/KnowledgeGraphModal.tsx
+++ b/src/components/KnowledgeGraphModal/KnowledgeGraphModal.tsx
@@ -33,40 +33,9 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
   );
 
   let myCy: cytoscape.Core;
-  // create a reference to the parent container element
-  const containerRef = React.useRef<HTMLElement | null>(null);
-
-  // use the useState hook to store the width and height of the component
-  const [style, setStyle] = React.useState({});
 
   const [error, setError] = React.useState<boolean>(false);
   const [newElements, setNewElements] = React.useState<any>(elements);
-
-  // update the width and height of the component when the component is mounted
-  React.useEffect(() => {
-    containerRef.current = document.getElementById("cytoscape-graph-container");
-    if (containerRef.current) {
-      setStyle({
-        width: 0.85 * containerRef.current.clientWidth,
-        height: 0.85 * containerRef.current.clientHeight,
-      });
-    }
-  }, [containerRef, domIDs.root]);
-
-  // update the width and height of the component whenever the parent container changes
-  React.useEffect(() => {
-    function handleResize() {
-      if (containerRef.current) {
-        setStyle({
-          width: 0.85 * containerRef.current.clientWidth,
-          height: 0.85 * containerRef.current.clientHeight,
-        });
-      }
-    }
-
-    // add an event listener to listen for resize events
-    window.addEventListener("resize", handleResize);
-  });
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const graphStyle = require("./cy-style.json");
@@ -209,23 +178,17 @@ const KnowledgeGraphModal: FC<KnowledgeGraphModalProps> = ({
                           duration: 1000,
                         }).play();
                       });
-                      cy.on("ready", function () {
-                        console.log("ready");
-                        setTimeout(() => {
-                          cy.animation({
-                            fit: {
-                              eles: newElements,
-                              padding: 10,
-                            },
-                            easing: "ease-in-out",
-                            duration: 1000,
-                          }).play();
-                        }, 500);
-                      });
+
+                      // Get reference to the component
                       myCy = cy;
+
+                      // Make it so the graph is automatically fitted into container when it is resized
+                      cy.on("resize", () => {
+                        zoomOut();
+                      });
                     }}
                     elements={newElements}
-                    style={style}
+                    style={{ width: "50vw", height: "70vh" }}
                     stylesheet={graphStyle}
                     layout={layout}
                     wheelSensitivity={0.2}


### PR DESCRIPTION
# Description

- The Knowledge Graph component now loads with the proper size and at the center of the container
- I wanted to use the `%` notation for `width` and `height` in the style element, but for some reason, the component does not load properly with those options
- Due to these issues being fixed, the node coordinates aren't messed up at the beginning, so the zooming in feature mostly works as expected. It is still possible for the zoom to not center on the selected node on the first click, but it is much better than before. 
- I couldn't quite iron it out since I could find no further info on this anywhere online or in cytoscape docs. It is likely connected to how the various containers are loaded and the component not being aware of these changes, therefore zooming into the incorrect coordinates. Once the user selects the next node or clicks on `Zoom out`, all the following zoom-ins work as expected, even when a new graph is loaded using `Set as Main Paper`
- The zoom-in is not as significant as before, makes it seem less 'jumpy' when changing focus between nodes
- Made the modal larger
- Haven't added any tests since Sai is working on tests for the component, but also don't think any need to be added due to this fix

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please include screenshots of new or changed components, templates & pages

# Reference JIRA tickets : 

- SA-#173

# Checklist:

Put an "x" in the brackets to check the checkbox.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
- [x] I have made corresponding changes to JIRA tickets
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have merged develop into my branch and resolved possible conflicts
