### PR TITLE
toolbar button fix, hopefully

### DIFF
--- a/public/web/customOnLoad.js
+++ b/public/web/customOnLoad.js
@@ -1,0 +1,4 @@
+window.onload = () => {
+  editToolBar();
+  importParentStyles();
+};

--- a/public/web/customToolbar.js
+++ b/public/web/customToolbar.js
@@ -23,7 +23,7 @@ function openSidebarTool(buttonId, calledFromPDFEventBus = false) {
   if (!button || !sidebar || !toolbarButtons) return;
 
   // Open the sidebar if it is not already open
-  // Only open on button click
+  // Only open on button click - on first load pdf.js opens it anyway
   if (!calledFromPDFEventBus && !sidebar?.classList.contains("sidebarOpen")) {
     document.getElementById("sidebarToggle").click();
   }
@@ -98,6 +98,8 @@ function removeElement(elemID) {
   element.parentNode.removeChild(element);
 }
 
+// Used to open the stored tool on first page load
+// After the initial tool loading, the listener is removed
 PDFViewerApplication.initializedPromise.then(() => {
   const f = (e) => {
     if (typeof e.view === "number" && e.view != 0) {

--- a/public/web/importStyles.js
+++ b/public/web/importStyles.js
@@ -17,5 +17,3 @@ function importParentStyles() {
   }
   document.getElementsByTagName("head")[0].appendChild(style);
 }
-
-importParentStyles();

--- a/public/web/viewer.html
+++ b/public/web/viewer.html
@@ -43,6 +43,7 @@ See https://github.com/adobe-type-tools/cmap-resources
     <script src="viewer.js"></script>
     <script src="customToolbar.js"></script>
     <script src="importStyles.js"></script>
+    <script src="customOnLoad.js"></script>
   </head>
 
   <body tabindex="1">
@@ -52,7 +53,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           <div id="toolbarSidebarLeft">
             <div
               id="sidebarViewButtons"
-              class="splitToolbarButton toggled"
+              class="splitToolbarButton"
               role="radiogroup"
             ></div>
           </div>
@@ -77,7 +78,7 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
         </div>
         <div id="sidebarContent">
-          <div id="thumbnailView"></div>
+          <div id="thumbnailView" class="hidden"></div>
           <div id="outlineView" class="hidden"></div>
           <div id="attachmentsView" class="hidden"></div>
           <div id="layersView" class="hidden"></div>
@@ -547,7 +548,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                 </button>
                 <button
                   id="viewThumbnail"
-                  class="customLayoutIconButton sidebarToolButton toggled active"
+                  class="customLayoutIconButton sidebarToolButton"
                   title="Show Thumbnails"
                   tabindex="12"
                   data-l10n-id="thumbs"


### PR DESCRIPTION
# Description

Sometimes the toolbar buttons wouldn't load correctly - specifically, when the localStorage `pdfjs.history` item was empty. I removed localStorage stuff from our code and added some listeners to PDFViewerApplication's `sidebarviewchange` in the event bus. I also had to make some changes in the tool opening and closing functions - now the sidebar toggle button is clicked automatically when needed (even though it's not visible).

**Please try to break this, I've tested it manually a lot but still don't know if it will always work**

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

not really applicable

# Reference JIRA tickets : 

- there was no Jira ticket for this

# Checklist:

Put an "x" in the brackets to check the checkbox.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to JIRA tickets
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have merged develop into my branch and resolved possible conflicts
