### PR TITLE
Sa 183/ref canvas stuck fix

### DIFF
--- a/cypress/e2e/reference.cy.ts
+++ b/cypress/e2e/reference.cy.ts
@@ -55,10 +55,15 @@ describe("Clicking on a reference shows a pop-up and opens it in sidebar", () =>
       const annotation = $iframeData.find(".internalLink");
       cy.wrap(annotation[1])
         .click()
+        .wait(3000)
         .then(() => {
           const referenceCanvas = $iframeData.find(".reference-canvas");
           const referenceToolCanvas = $iframeData.find(".referenceview-canvas");
           const refrenceWrapper = $iframeData.find(".reference-view-wrapper");
+          const jumpToContentButton = $iframeData.find(
+            ".reference-content-button",
+          );
+          expect(jumpToContentButton).to.be.visible;
           expect(refrenceWrapper).to.not.exist; //Wrapper should not exist when a reference is clicked
           expect(referenceCanvas).to.exist; // Check if pop up exists
           expect(referenceToolCanvas).to.be.visible; // Check if reference is displayed in toolbar
@@ -67,16 +72,28 @@ describe("Clicking on a reference shows a pop-up and opens it in sidebar", () =>
   });
 });
 
-// describe("Clicking on a reference shows a pop-up and opens it in sidebar", () => {
-//   it("passes", () => {
-//     getIframeFromUrl(pdfUrl).then(($iframeData) => {
-//       const annotation = $iframeData.find(".internalLink");
-//       cy.wrap(annotation[1])
-//         .trigger("mouseover")
-//         .then(() => {
-//           const referenceCanvas = $iframeData.find(".reference-canvas");
-//           expect(referenceCanvas).to.exist; // Check if pop up exists
-//         });
-//     });
-//   });
-// });
+describe("Once ‘Jump to Content’ button is clicked it becomes disabled and ‘Jump back’ button becomes enabled.", () => {
+  it("passes", () => {
+    getIframeFromUrl(pdfUrl).then(($iframeData) => {
+      const annotation = $iframeData.find(".internalLink");
+      cy.wrap(annotation[1])
+        .click()
+        .wait(3000)
+        .then(() => {
+          const jumpToContentButton = $iframeData.find(
+            ".reference-content-button",
+          );
+          expect(jumpToContentButton).not.be.disabled;
+          const jumpBackButton = $iframeData.find(".reference-back-button");
+          expect(jumpBackButton).not.be.enabled;
+          cy.wrap(jumpToContentButton)
+            .click()
+            .wait(3000)
+            .then(() => {
+              expect(jumpToContentButton).not.be.enabled;
+              expect(jumpBackButton).not.be.disabled;
+            });
+        });
+    });
+  });
+});

--- a/public/build/pdf.js
+++ b/public/build/pdf.js
@@ -12336,8 +12336,8 @@
               () => {
                 var canvas =
                   document.getElementsByClassName("reference-canvas");
-                for (var i = 0; i < canvas.length; i++) {
-                  canvas.item(i).remove();
+                while (canvas.length > 0) {
+                  canvas[0].parentNode.removeChild(canvas[0]);
                 }
               },
               false,

--- a/public/build/pdf.js
+++ b/public/build/pdf.js
@@ -12324,7 +12324,7 @@
                           };
                           page.render(w);
                         }),
-                        container.after(c)
+                        container.after(c);
                     });
                   });
                 }
@@ -12334,7 +12334,11 @@
             container.addEventListener(
               "mouseleave",
               () => {
-                c.remove();
+                var canvas =
+                  document.getElementsByClassName("reference-canvas");
+                for (var i = 0; i < canvas.length; i++) {
+                  canvas.item(i).remove();
+                }
               },
               false,
             );

--- a/public/build/pdf.js
+++ b/public/build/pdf.js
@@ -12271,11 +12271,11 @@
             //
             //mouseover create a canvas
             //
+            const c = document.createElement("canvas");
             container.addEventListener(
               "mouseenter",
               (event) => {
                 if (data.dest) {
-                  const c = document.createElement("canvas");
                   c.className = "reference-canvas";
                   c.style.top = event.clientY + "px";
 
@@ -12324,17 +12324,17 @@
                           };
                           page.render(w);
                         }),
-                        container.after(c),
-                        container.addEventListener(
-                          "mouseleave",
-                          () => {
-                            c.remove();
-                          },
-                          false,
-                        );
+                        container.after(c)
                     });
                   });
                 }
+              },
+              false,
+            );
+            container.addEventListener(
+              "mouseleave",
+              () => {
+                c.remove();
               },
               false,
             );


### PR DESCRIPTION
# Description

It would sometimes happen that the refrence canvas would stick to the screen and not be removed when the mouse moved from the reference link. I think it's fixed now.

**Please try to recreate the bug and let me know.**

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# Reference JIRA tickets : 

- SA-183

# Checklist:

Put an "x" in the brackets to check the checkbox.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have made corresponding changes to JIRA tickets
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have merged develop into my branch and resolved possible conflicts
